### PR TITLE
bugfix: unswap pins in usbconfig.h

### DIFF
--- a/src/usbconfig.h
+++ b/src/usbconfig.h
@@ -30,11 +30,11 @@ section at the end of this file).
 /* This is the port where the USB bus is connected. When you configure it to
  * "B", the registers PORTB, PINB and DDRB will be used.
  */
-#define USB_CFG_DMINUS_BIT      2
+#define USB_CFG_DMINUS_BIT      7
 /* This is the bit number in USB_CFG_IOPORT where the USB D- line is connected.
  * This may be any bit in the port.
  */
-#define USB_CFG_DPLUS_BIT       7
+#define USB_CFG_DPLUS_BIT       2
 /* This is the bit number in USB_CFG_IOPORT where the USB D+ line is connected.
  * This may be any bit in the port. Please note that D+ must also be connected
  * to interrupt pin INT0! [You can also use other interrupts, see section


### PR DESCRIPTION
The library, as is, fails to enumerate as a USB device on my machine.

The wiring diagram in `circuits/arduino_vusb_dev_schematic.png` shows the `D+` line connected to pin 2, and the `D-` line connected to pin 7.

`usbconfig.h` currently shows the opposite, with `D+` = 7, and `D-` = 2
After swapping these values, the library works as expected on my machine. 